### PR TITLE
Set BayesianTensorFiltering force_psd to `True`

### DIFF
--- a/functionalmf/factor.py
+++ b/functionalmf/factor.py
@@ -30,7 +30,7 @@ class BayesianTensorFiltering(_BayesianModel):
                        W_init=None, V_init=None,
                        W_true=None, V_true=None,
                        stability=1e-6, 
-                       force_psd=False, 
+                       force_psd=True, 
                        force_psd_eps=1e-6,
                        force_psd_attempts=4,
                        **kwargs):


### PR DESCRIPTION
Can sometimes get a "not positive definite" error with the BayesianTensorFiltering model (`sksparse.cholmod.CholmodNotPositiveDefiniteError`). Set `force_psd` to `True` to (hopefully) avoid this.